### PR TITLE
[miner] Removed requirement to run app with root

### DIFF
--- a/src/consts/const_global.js
+++ b/src/consts/const_global.js
@@ -200,7 +200,7 @@ consts.SETTINGS = {
         SSL: true,
 
 
-        PORT: 80, //port
+        PORT: 8081, //port
     },
 
     PARAMS: {


### PR DESCRIPTION
Binding to port 80 requires root access and it is likely that
a web server is already listening to the same port, thus making
it hard for the average user to start mining.