### PR TITLE
Add terminal npm script for env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ transactionsDB/
 certificates/ca_bundle.crt
 certificates/certificate.crt
 certificates/private.key
+
+.with.json

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "coverage": "npm run build_terminal  && istanbul cover _mocha dist/tests/main.test.js -x *.test.js && npm run show_coverage",
     "show_coverage": "node src/tests/browser/show-coverage.test.js",
     "build_terminal_worker": "webpack --config build_webpack/webpack.terminal-worker.config.js",
+    "with": "node scripts/npm/with",
     "commands": "npm run build_terminal_menu && npm run build_terminal_worker && node --max_old_space_size=6144 dist_bundle/terminal-menu-bundle.js"
   },
   "repository": {

--- a/scripts/npm/with.js
+++ b/scripts/npm/with.js
@@ -1,0 +1,34 @@
+const Parser = require('./with/parser.js');
+const Storage = require('./with/storage.js');
+
+// avoid running the code again if this one gets required
+if (require.main !== module) {
+    // easy access to read & save
+    module.exports = {
+        read: (data, source) => {
+            return (new Storage(source)).read(data);
+        },
+        save: (data, source) => {
+            return (new Storage(source)).save(data);
+        }
+    };
+
+    return false;
+}
+
+const parser = new Parser();
+const storage = new Storage();
+
+// Add custom expressions here. Order matters!
+// ...
+
+// default expressions
+parser.addNamespaceExpression();
+parser.addKeyValueExpression();
+parser.addOptionExpression();
+
+// parse
+parser.parse();
+
+// save
+storage.save(parser.all());

--- a/scripts/npm/with.js
+++ b/scripts/npm/with.js
@@ -20,12 +20,14 @@ const parser = new Parser();
 const storage = new Storage();
 
 // Add custom expressions here. Order matters!
-// ...
+parser.addOptions({
+    dev: false,
+});
 
 // default expressions
-parser.addNamespaceExpression();
-parser.addKeyValueExpression();
-parser.addOptionExpression();
+parser.addNamespace(); // finds: namespace:key=value
+parser.addKeyValue(); // finds: key=value
+parser.addOption('overwrite', false); // finds: key
 
 // parse
 parser.parse();

--- a/scripts/npm/with/parser.js
+++ b/scripts/npm/with/parser.js
@@ -1,0 +1,170 @@
+class Expression {
+    constructor(name, regExp, validation) {
+        this._name = name;
+        this._regExp = regExp;
+        this._validation = validation;
+    }
+
+    name() {
+        return this._name;
+    }
+
+    match(arg) {
+        const match = arg.match(this._regExp);
+
+        return this._validation(match, arg, this);
+    }
+}
+
+class Parser {
+    constructor() {
+        this._expressions = {};
+        this._arguments = {};
+
+        this._sanitise_expression = {
+            number: new RegExp(/[\d]{1,}/),
+        };
+    }
+
+    addExpression(name, regExp, validation = (arg) => {}) {
+        const expr = new Expression(name, regExp, validation);
+
+        this._expressions[expr.name()] = expr;
+
+        return this;
+    }
+
+    addKeyValueExpression() {
+        this.addExpression('default_key_value', new RegExp(/^(.*?)=(.*?)$/), (match, arg, self) => {
+            if (!match) {
+                return false;
+            }
+
+            for (let i = 1; i <= 2; i++) {
+                if (!match[i].length) {
+                    parser.exit(`Invalid argument: "${arg}"`);
+                }
+            }
+
+            return {
+                key: `${match[1].toUpperCase()}`,
+                value: match[2],
+            };
+        });
+
+        return this;
+    }
+
+    addNamespaceExpression() {
+        this.addExpression('default_namespace', new RegExp(/^(.*?):(.*?)=(.*?)$/), (match, arg, self) => {
+            if (!match) {
+                return false;
+            }
+
+            for (let i = 1; i <= 3; i++) {
+                if (!match[i].length) {
+                    parser.exit(`Invalid argument: "${arg}"`);
+                }
+            }
+
+            return {
+                namespace: match[1].toUpperCase(),
+                key: match[2].toUpperCase(),
+                value: match[3],
+            };
+        });
+
+        return this;
+    }
+
+    addOptionExpression() {
+        this.addExpression('default_option', new RegExp(/^is-(.*)$/i), (match) => {
+            if (match) {
+                return { key: match[1].toUpperCase(), value: true };
+            }
+        });
+
+        return this;
+    }
+
+    parse() {
+        // keep track of what we find
+        const found = {};
+
+        // ignore first two and loop through the rest
+        process.argv.slice(2).forEach((arg) => {
+            Object.keys(this._expressions).forEach((key) => {
+                // we already had a match
+                if (found[arg]) {
+                    return false;
+                }
+
+                const result = this._expressions[key].match(arg);
+                if (!result) {
+                    return false;
+                }
+
+                // combine namespace + key for simple tracking
+                if (result.namespace) {
+                    arg = `${result.namespace}_${result.key}`;
+                }
+
+                // mark it as found
+                found[arg] = true;
+
+                // cleanup value
+                result.value = this._sanitiseValue(result.value);
+
+                // save
+                if (result.namespace) {
+                    if (!this._arguments[result.namespace]) {
+                        this._arguments[result.namespace] = {};
+                    }
+
+                    this._arguments[result.namespace][result.key] = result.value;
+
+                    return false;
+                }
+
+                this._arguments[result.key] = result.value;
+            });
+        });
+
+        return this._arguments;
+    }
+
+    all() {
+        return this._arguments;
+    }
+
+    exit() {
+        console.log.apply(undefined, arguments);
+
+        process.exit(1);
+    }
+
+    _sanitiseValue(value) {
+        if (typeof value == 'boolean') {
+            return value;
+        }
+
+        if (value.toLowerCase() == 'false') {
+            return false;
+        } else if (value.toLowerCase() == 'true') {
+            return true;
+        }
+
+        value = value.trim();
+
+        const match = value.match(this._sanitise_expression.number);
+
+        // matched numbers && only numbers
+        if (match && match[0].length == value.length) {
+            value = parseInt(value);
+        }
+
+        return value;
+    }
+}
+
+module.exports = Parser;

--- a/scripts/npm/with/storage.js
+++ b/scripts/npm/with/storage.js
@@ -1,0 +1,58 @@
+const FS = require('fs');
+
+class Storage {
+    constructor(source = '.with.json') {
+        this.source = source;
+    }
+
+    save(data = {}) {
+        FS.writeFileSync(this.source, JSON.stringify(data, null, 4), () => {});
+
+        return this;
+    }
+
+    read(data = {}) {
+        // env fix
+        const wrap_string_value = (target) => {
+            if (typeof target == 'string') {
+                return `"${target}"`;
+            }
+
+            if (typeof target == 'object') {
+                Object.keys(target).forEach((key) => {
+                    const value = target[key];
+
+                    target[key] = (typeof value == 'string') ? `"${value}"` : value;
+                });
+            }
+
+            return target;
+        };
+
+        if (FS.existsSync(this.source)) {
+            const content = FS.readFileSync(this.source, 'utf8');
+
+            const json = JSON.parse(content.trim());
+
+            Object.keys(json).forEach((key) => {
+                if (typeof json[key] == 'object') {
+                    if (!data[key]) {
+                        data[key] = {};
+                    }
+
+                    data[key] = Object.assign(data[key], wrap_string_value(json[key]));
+
+                    return false;
+                }
+
+                data[key] = wrap_string_value(json[key]);
+            });
+
+            return data;
+        }
+
+        return data;
+    }
+}
+
+module.exports = Storage;


### PR DESCRIPTION
Rewrites default arguments or adds new ones.
Given arguments are being saved in .with.json in root directory.

Example:
npm run with server:domain=google.com server:port=80 is-dev browser=false && npm run commands

Insight:
- server:domain=google.com gets translated to SERVER_DOMAIN and the value "google.com" - available via process.env.SERVER_DOMAIN
- is-dev to DEV- available via process.env.DEV
- browser to BROWSER - available via process.env.BROWSER
