### PR TITLE
Add option to pass commands from terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ transactionsDB/
 certificates/ca_bundle.crt
 certificates/certificate.crt
 certificates/private.key
+
+.with.json

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "coverage": "npm run build_terminal  && istanbul cover _mocha dist/tests/main.test.js -x *.test.js && npm run show_coverage",
     "show_coverage": "node src/tests/browser/show-coverage.test.js",
     "build_terminal_worker": "webpack --config build_webpack/webpack.terminal-worker.config.js",
+    "with": "node scripts/npm/with",
     "commands": "npm run build_terminal_menu && npm run build_terminal_worker && node --max_old_space_size=6144 dist_bundle/terminal-menu-bundle.js"
   },
   "repository": {

--- a/scripts/npm/with.js
+++ b/scripts/npm/with.js
@@ -1,0 +1,115 @@
+const Commands = require('./with/commands.js');
+
+const commands = new Commands();
+
+// Server
+commands.add({
+    name: 'server:domain',
+    help: 'Sets the domain of your express server',
+    default: 'localhost',
+});
+
+commands.add({
+    name: 'server:port',
+    help: 'Sets the port of your express server',
+    default: 443,
+});
+
+// Max
+commands.add({
+    name: 'max:browser',
+    help: 'Sets maximum connections from browser',
+    default: 1000,
+});
+
+commands.add({
+    name: 'max:terminal',
+    help: 'Sets maximum connections from terminal',
+    default: 400,
+});
+
+commands.add({
+    name: 'max:workers',
+    help: 'Sets the number of workers\n\
+        Notes: \n\
+        using -1 will disable them\n\
+        using 0 will create cpus/2 workers',
+    default: -1,
+});
+
+// Miner
+commands.add({
+    name: 'miner:address',
+    help: 'Sets the mining address\n\
+        Notes:\n\
+        if not specified it uses the first address from database\n\
+        if no address in database, it creates a new one and uses it\n\
+        Example:\n\
+        miner:address=\'value\' (wrap the value in single quotes)',
+    default: false,
+});
+
+commands.add({
+    name: 'miner:pool',
+    help: 'Sets mining pool url\n\
+        Example:\n\
+        miner:address=\'value\' (wrap the value in single quotes)',
+    default: false,
+});
+
+commands.add({
+    name: 'miner:run',
+    help: 'Starts mining',
+    options: ['single', 'pool'],
+});
+
+// Pool
+commands.add({
+    name: 'pool:name',
+    help: 'Sets a name for your pool',
+});
+
+commands.add({
+    name: 'pool:address',
+    help: 'Sets the mining address of your pool\n\
+        Notes:\n\
+        if not specified it uses the first address from database\n\
+        if no address in database, it creates a new one and uses it\n\
+        Example:\n\
+        pool:address=\'value\' (wrap the value in single quotes)',
+    default: false,
+});
+
+commands.add({
+    name: 'pool:url',
+    help: 'Sets the url of your pool\n\
+        Example:\n\
+        pool:url=\'value\' (wrap the value in single quotes)',
+    default: false,
+});
+
+commands.add({
+    name: 'pool:fee',
+    help: 'Sets the percentage fee of your pool',
+    default: .5,
+});
+
+commands.add({
+    name: 'pool:referral_fee',
+    help: 'Sets the percetange referral fee of your pool',
+    default: .5,
+});
+
+commands.add({
+    name: 'pool:run',
+    help: 'Starts the pool',
+});
+
+// Add commands logic:
+// if (!commands.find('test')) {
+//     Commands.exit('Command "test" is missing!');
+// }
+
+// Process & save
+commands.process();
+Commands.save(commands);

--- a/scripts/npm/with/command.js
+++ b/scripts/npm/with/command.js
@@ -1,0 +1,159 @@
+class Command {
+    constructor() {
+        this._namespace = undefined;
+        this._name = undefined;
+        this._help = undefined;
+        this._value = undefined;
+        this._default = undefined;
+        this._options = undefined;
+        this._builtin = undefined;
+    }
+
+    namespace() {
+        return this._namespace;
+    }
+
+    setName(name) {
+        this._name = name.toLowerCase();
+
+        const parts = this._name.split(':');
+        if (parts.length > 1) {
+            this._namespace = parts[0];
+        }
+
+        return this;
+    }
+
+    name() {
+        return this._name;
+    }
+
+    setHelp(help) {
+        this._help = help;
+
+        return this;
+    }
+
+    help() {
+        return this._help;
+    }
+
+    setValue(value, is_default = false) {
+        if (typeof value === 'string') {
+            if (value.toLowerCase() === 'true') {
+                value = true;
+            } else if (value.toLowerCase() === 'false') {
+                value = false;
+            } else {
+                let temp = parseFloat(value);
+                if (temp !== NaN) {
+                    // add leading 0 if passed without it
+                    if (temp.toString().startsWith('0.')) {
+                        temp += 0;
+                    }
+
+                    if (temp.toString() === value) {
+                        value = temp;
+                    }
+                }
+            }
+        }
+
+        if (this.options()) {
+            let found = false;
+            this._options.forEach((option) => {
+                if (option === value) {
+                    found = true;
+                }
+            });
+
+            if (!found) {
+                console.log(`Command "${this.name()}" has options ${this.optionsList()} [given: "${value}"]`);
+
+                process.exit(1);
+            }
+        }
+
+        if (is_default) {
+            this._default = value;
+
+            return this;
+        }
+
+        this._value = value;
+
+        return this;
+    }
+
+    value() {
+        if (this._value === undefined) {
+            return this._default;
+        }
+
+        return this._value;
+    }
+
+    defaultValue() {
+        return this._default;
+    }
+
+    setOptions(options) {
+        if (options instanceof Array) {
+            options.forEach((option, index) => {
+                options[index] = option.toLowerCase();
+            });
+
+            this._options = options;
+        }
+
+        return this;
+    }
+
+    options() {
+        return this._options;
+    }
+
+    optionsList() {
+        return this._options.join('/');
+    }
+
+    setBuiltin(builtin) {
+        this._builtin = builtin || false;
+
+        return this;
+    }
+
+    isBuiltin() {
+        return this._builtin;
+    }
+
+    json() {
+        const json = {};
+        if (!this._namespace) {
+            json[this.name()] = this.value();
+
+            return json;
+        }
+
+        json[this._namespace] = {};
+        json[this._namespace][this._name.split(':')[1]] = this.value();
+
+        return json;
+    }
+
+    static factory(data) {
+        const command = new Command();
+
+        command.setName(data.name);
+        command.setHelp(data.help);
+        command.setValue(data.value);
+        command.setValue(data.default, true); // default
+        command.setOptions(data.options);
+
+        command.setBuiltin(data.builtin);
+
+        return command;
+    }
+}
+
+module.exports = Command;

--- a/scripts/npm/with/commands.js
+++ b/scripts/npm/with/commands.js
@@ -1,0 +1,165 @@
+const Storage = require('./storage.js');
+const Command = require('./command.js');
+
+class Commands {
+    constructor() {
+        this._list = {};
+
+        // builtins are ignored in json()
+        this.add({ name: 'help', help: 'Displays this help message', builtin: true });
+        this.add({ name: 'save', help: 'Saves commands for later', default: false, builtin: true });
+
+        // development
+        this.add({ name: 'dev', help: 'Use development & show debug messages', default: false });
+    }
+
+    add(data) {
+        const command = Command.factory(data);
+
+        this._list[command.name()] = command;
+
+        return this;
+    }
+
+    find(name) {
+        name = name.toLowerCase();
+
+        return this._list[name];
+    }
+
+    process() {
+        const expression = new RegExp(/(.*)=(.*)$/);
+
+        process.argv.slice(2).forEach((arg) => {
+            let name = arg;
+            let value = undefined;
+
+            const match = arg.match(expression);
+            if (match) {
+                name = match[1];
+                value = match[2];
+            }
+
+            let command = this.find(name);
+            if (command) {
+                command.setValue(value);
+            }
+        });
+
+
+        const help = this.find('help');
+        if (process.argv.length == 2 || (help && help.value())) {
+            this.help();
+
+            process.exit(0);
+        }
+    }
+
+    json() {
+        const json = {};
+        Object.keys(this._list).forEach((name) => {
+            const command = this._list[name];
+
+            if (!command.isBuiltin()) {
+                const temp = command.json();
+
+                Object.keys(temp).forEach((key) => {
+                    if (!json[key]) {
+                        json[key] = {};
+                    }
+
+                    if (typeof temp[key] === 'object') {
+                        json[key] = Object.assign(json[key], temp[key]);
+
+                        return false;
+                    }
+
+                    json[key] = temp[key];
+                });
+            }
+        });
+
+        return json;
+    }
+
+    help() {
+        const color = {
+            green: '\x1b[32m',
+            yellow: '\x1b[33m',
+            reset: '\x1b[0m',
+            dim: '\x1b[2m',
+        };
+
+        const padding = 20; // command/new line padding
+        const no_tab = ['Example:', 'Notes:'];
+
+        // temporary solution
+        const sections = {};
+
+        Object.keys(this._list).forEach((name) => {
+            const command = this._list[name];
+
+            let section = '';
+            const ns = command.namespace();
+            if (ns && !sections[ns]) {
+                section = `${color.yellow}${ns}${color.reset}\n`;
+
+                sections[ns] = true;
+            }
+
+            let lines = command.help().split('\n');
+
+            let help = false;
+            lines.forEach((line, index) => {
+                // first line
+                if (!help) {
+                    // Note the space after section. Lower we use padding+1 because of it.
+                    help = `${section} ${color.green}${command.name().padEnd(padding)} ${color.reset}${line.trim()}`;
+
+                    if (command.defaultValue() !== undefined) {
+                        help = `${help} ${color.yellow}[default: ${command.defaultValue()}]${color.reset}`;
+                    }
+
+                    if (command.options()) {
+                        help = `${help} ${color.yellow}[options: ${command.optionsList()}]${color.reset}`;
+                    }
+
+                    return false;
+                }
+
+                // to tab or not to tab
+                let tabbed = '\t';
+                no_tab.forEach((str) => {
+                    if (line.indexOf(str) !== -1) {
+                        tabbed = '';
+                    }
+                });
+
+                help += `\n${"".padEnd(padding+1)} ${color.dim}${tabbed}${line.trim()}${color.reset}`;
+            });
+
+            console.log(help);
+        });
+    }
+
+    static exit() {
+        console.log.apply(undefined, arguments);
+
+        process.exit(1);
+    }
+
+    static save(commands) {
+        (new Storage()).save(commands.json(), commands.find('save').value());
+    }
+
+    static read(wrap_strings = true) {
+        const data = (new Storage()).read(wrap_strings);
+        if (!data) {
+            Commands.exit('No commands were found.\nYou need to run "npm run with"!');
+        }
+
+        return data;
+    }
+}
+
+module.exports = Commands;

--- a/scripts/npm/with/storage.js
+++ b/scripts/npm/with/storage.js
@@ -1,0 +1,81 @@
+const FS = require('fs');
+
+class Storage {
+    constructor(source = '.with') {
+        this.source = `${source}.json`;
+        this.temp_source = `${source}.temp.json`;
+    }
+
+    save(data, has_save) {
+        let source = this.source;
+        if (!has_save) {
+            source = this.temp_source;
+        }
+
+        FS.writeFileSync(source, JSON.stringify(data, null, 4), () => {});
+
+        return this;
+    }
+
+    read(wrap_strings) {
+        // env fix
+        const wrap_string_value = (target) => {
+            if (!wrap_strings) {
+                return target;
+            }
+
+            if (typeof target == 'string') {
+                return `"${target}"`;
+            }
+
+            if (typeof target == 'object') {
+                Object.keys(target).forEach((key) => {
+                    const value = target[key];
+
+                    target[key] = (typeof value == 'string') ? `"${value}"` : value;
+                });
+            }
+
+            return target;
+        };
+
+        // determine source
+        let source = this.temp_source;
+        let is_temp = true;
+        if (!FS.existsSync(source)) {
+            is_temp = false;
+            source = this.source;
+
+            if (!FS.existsSync(source)) {
+                return false;
+            }
+        }
+
+        // prepare data
+        const data = {};
+        const content = FS.readFileSync(source, 'utf8');
+        const current = JSON.parse(content.trim());
+        Object.keys(current).forEach((key) => {
+            if (typeof current[key] == 'object') {
+                if (!data[key]) {
+                    data[key] = {};
+                }
+
+                data[key] = Object.assign(data[key], wrap_string_value(current[key]));
+
+                return false;
+            }
+
+            data[key] = wrap_string_value(current[key]);
+        });
+
+        // remove temp file
+        if (is_temp) {
+            FS.unlinkSync(source);
+        }
+
+        return data;
+    }
+}
+
+module.exports = Storage;


### PR DESCRIPTION
You can test it in a file like build_webpack/webpack.terminal.config.js

const Commands = require('../scripts/npm/with/commands');
const data = Commands.read();
console.log(data);
process.exit(111); // for the sake of the test, let's stop here

Info:
- an error message should show up if you never ran "npm run with"
- use "npm run with" to show options
- use "npm run with save" (to save the default config just to test it out)