### PR TITLE
Fix for an API endpoint

### DIFF
--- a/src/node/sockets/node-server/API/Node-API-Private.js
+++ b/src/node/sockets/node-server/API/Node-API-Private.js
@@ -27,9 +27,9 @@ class NodeAPIPrivate{
 
         let content = {
             version: '0.1',
-            address: address.address,
-            publicKey: address.publicKey,
-            privateKey: address.privateKey,
+            address: address,
+            publicKey: publicKey,
+            privateKey: privateKey,
         };
 
         try {

--- a/src/node/sockets/node-server/API/Node-API-Private.js
+++ b/src/node/sockets/node-server/API/Node-API-Private.js
@@ -20,10 +20,10 @@ class NodeAPIPrivate{
     }
 
     async walletImport(req, res){
-
+        
+        let address = req.address;
+        let publicKey = req.publicKey;
         let privateKey = req.privateKey;
-
-        let address = InterfaceBlockchainAddressHelper.generateAddress(undefined, privateKey);
 
         let content = {
             version: '0.1',
@@ -38,7 +38,7 @@ class NodeAPIPrivate{
 
             if (answer.result === true) {
                 await Blockchain.Wallet.saveWallet();
-                return {result: true, address: address.address};
+                return {result: true, address: address};
             } else
                 return {result: false, message: answer.message};
 


### PR DESCRIPTION
Calls to the `/wallets/import` endpoint fail with `{"result":false,"message":"Address already exists!"}`, regardless of the `privateKey` parameter.

The proposed solution is less elegant, but it works.