### PR TITLE
Fix for #74

### DIFF
--- a/src/node/sockets/node-server/express/Node-Express.js
+++ b/src/node/sockets/node-server/express/Node-Express.js
@@ -194,7 +194,7 @@ class NodeExpress{
             for (let k in req.params)
                 req.params[k] = decodeURIComponent(req.params[k]);
 
-            let answer = await callback(req.params, res);
+            let answer = await callback(req, res);
             res.json(answer);
 
         } catch (exception){


### PR DESCRIPTION
This is not a good idea as pointed out in https://github.com/WebDollar/Node-WebDollar/issues/74, `req.params` is being sent instead of `req` as the code implies throughout the usages of the function. I spent a lot of time debugging the code because I was expecting `req`.
