### PR TITLE
db: pouchdb should save only one revision

### DIFF
--- a/src/common/satoshmindb/Interface-SatoshminDB.js
+++ b/src/common/satoshmindb/Interface-SatoshminDB.js
@@ -22,7 +22,7 @@ class InterfaceSatoshminDB {
     _start(){
 
         try {
-            this.db = new pounchdb(this.dbName);
+            this.db = new pounchdb(this.dbName, {revs_limit: 1});
         } catch (exception){
             console.error("InterfaceSatoshminDB exception", pounchdb);
         }


### PR DESCRIPTION
If the revision limit is not set,
for each possible fork, the block information will be duplicated,
this leading to huge amounts of useless data saved on disk.