### PR TITLE
Remove node on Port 80 for CryptoCoinGB

### DIFF
--- a/src/node/sockets/node-clients/service/discovery/fallbacks/fallback_nodes_list.js
+++ b/src/node/sockets/node-clients/service/discovery/fallbacks/fallback_nodes_list.js
@@ -48,7 +48,6 @@ export default {
         {"addr": ["https://node-eu.int-webd.com:5009"]}, // Thanks to @int_webd
         {"addr": ["https://node-eu.int-webd.com:5010"]}, // Thanks to @int_webd
         
-        {"addr": ["https://cryptocoingb.ddns.net:80"]}, // Thanks to CryptoCoinGB
         {"addr": ["https://cryptocoingb.ddns.net:8080"]}, // Thanks to CryptoCoinGB
         
         // ----------------------------------------- inactive nodes        


### PR DESCRIPTION
Removal of Port 80 for CryptoCoinGB as I was having issues receiving connections on this port, they were very sporadic. As it wasn't doing much use I've decided to take this hardware down temporarily to do some upgrades on it, so would like the port removed from the list for the time being. Thank you :)