### PR TITLE
Update Node-API-Public-Pools.js

### DIFF
--- a/src/node/sockets/node-server/API/public/Node-API-Public-Pools.js
+++ b/src/node/sockets/node-server/API/public/Node-API-Public-Pools.js
@@ -4,7 +4,6 @@ import NODE_CONSENSUS_TYPE from "node/lists/types/Node-Consensus-Type"
 import Blockchain from "main-blockchain/Blockchain";
 import BufferExtended from "common/utils/BufferExtended";
 import InterfaceBlockchainAddressHelper from "common/blockchain/interface-blockchain/addresses/Interface-Blockchain-Address-Helper";
-const JSON = require('circular-json');
 
 class NodeAPIPublicPools {
 


### PR DESCRIPTION
Remove line 7, const JSON = require('circular-json');

It causes 'npm run commands' to fail as it is not a dependency on install and doesn't exist. This has already been removed in the fast loading branch, but is causing issues for anyone completing a fresh install of the terminal miner as it requires the 'circular-json' dependency.

With this line removed, 'npm run commands' works fine and I can see no other effect on the operation of the functions.