### PR TITLE
Create blockchainDB3 Backup Locations

### DIFF
--- a/tutorials/blockchainDB3 Backup Locations
+++ b/tutorials/blockchainDB3 Backup Locations
@@ -2,18 +2,44 @@ WebDollar.io blockchainDB3 backups
 
 -----------
 
+***PLEASE NOTE THIS SOURCE IS CURRENTLY UNAVAILABLE***
 Primary high speed backup source provided by VPN Romania:
-https://webdftp.vpnromania.ro/ftp/blockchainDB3.tar.gz *Currently Unavailable*
+https://webdftp.vpnromania.ro/ftp/blockchainDB3.tar.gz
 
-Instructions: As per other tutorials
+Instructions: 
++ from within your WebDollar folder
++ delete the old blockchainDB3 directory if it exists (command: sudo rm -r blockchainDB3)
++ make a new empty blockchainDB3 directory (command: mkdir blockchainDB3)
++ open the new directory (command: cd blockchainDB3)
++ use 'wget' to download the file from the link above (command: wget http://cryptocoingb.ddns.net:9000/blockchainDB3.tar.gz)
++ extract the file - it will create the directory for you (command: tar -zxvf blockchainDB3.tar.gz -C .)
 
 -----------
 
 Secondary medium speed backup source provided by CryptoCoinGB:
 http://webd-blockchain.ddns.net:8080/blockchainDB3.tar.gz
 
-Instructions:
+Backups are created at 00:00, 06:00, 12:00 and 18:00 GMT.
+If your download is initiated at these times it may fail due to the file being updated.
 
-delete the old blockchainDB3 directory if it exists (command: sudo rm -r blockchainDB3)
-use 'wget' to download the file from the link above (command: wget http://cryptocoingb.ddns.net:9000/blockchainDB3.tar.gz)
-extract the file - it will create the directory for you (command: tar -zxvf blockchainDB3.tar.gz -C .)
+Instructions:
++ from within your WebDollar folder
++ delete the old blockchainDB3 directory if it exists (command: sudo rm -r blockchainDB3)
++ use 'wget' to download the file from the link above (command: wget http://webd-blockchain.ddns.net:8080/blockchainDB3.tar.gz)
++ extract the file - it will create the directory for you (command: tar -zxvf blockchainDB3.tar.gz -C .)
+
+-----------
+
+Fallback slow speed backup source provided by CryptoCoinGB:
+http://cryptocoingb.ddns.net:9000/blockchainDB3.tar.gz
+
+Backups are created at 01:00 GMT.
+If your download is initiated at this time it may fail due to the file being updated.
+
+Instructions:
++ from within your WebDollar folder
++ delete the old blockchainDB3 directory if it exists (command: sudo rm -r blockchainDB3)
++ use 'wget' to download the file from the link above (command: http://cryptocoingb.ddns.net:9000/blockchainDB3.tar.gz)
++ extract the file - it will create the directory for you (command: tar -zxvf blockchainDB3.tar.gz -C .)
+
+-----------

--- a/tutorials/blockchainDB3 Backup Locations
+++ b/tutorials/blockchainDB3 Backup Locations
@@ -1,0 +1,19 @@
+WebDollar.io blockchainDB3 backups
+
+-----------
+
+Primary high speed backup source provided by VPN Romania:
+https://webdftp.vpnromania.ro/ftp/blockchainDB3.tar.gz *Currently Unavailable*
+
+Instructions: As per other tutorials
+
+-----------
+
+Secondary medium speed backup source provided by CryptoCoinGB:
+http://webd-blockchain.ddns.net:8080/blockchainDB3.tar.gz
+
+Instructions:
+
+delete the old blockchainDB3 directory if it exists (command: sudo rm -r blockchainDB3)
+use 'wget' to download the file from the link above (command: wget http://cryptocoingb.ddns.net:9000/blockchainDB3.tar.gz)
+extract the file - it will create the directory for you (command: tar -zxvf blockchainDB3.tar.gz -C .)


### PR DESCRIPTION
A list of current blockchainDB3 backup locations that can be referenced from other tutorials. This will make it easier to update URLs in future and hold them in one easy to identify location.