### PR TITLE
Correct launch webserver command

### DIFF
--- a/tutorials/how-to-deploy-webdollar-pool.md
+++ b/tutorials/how-to-deploy-webdollar-pool.md
@@ -46,7 +46,7 @@ npm run commands # better use screen command or open another terminal - Run this
 #### vue-Frontend - Running by default on PORT 9094!
 ```shell
 cd vue-Frontend
-npm run dev # better use screen command or open another terminal - Run this command after step 3
+npm run start # better use screen command or open another terminal - Run this command after step 3
 ```
 ### 5. Configuring your WebDollar Pool (run commands in Node Window)
 ```shell


### PR DESCRIPTION
'npm run dev' does not work as it is not referenced in package.json within the 'vue-Frontend' folder to start the webserver. 'npm run start' does work however and successfully starts the webserver.