### PR TITLE
Catch pool URLs with multiple versions & provide better hints for pool

### DIFF
--- a/src/common/mining-pools/common/Pools-Utils.js
+++ b/src/common/mining-pools/common/Pools-Utils.js
@@ -182,8 +182,15 @@ class PoolsUtils {
         url = this.substrNext(url);
 
         if (version !== "") version = parseInt(version);
+	
 
         let poolName = this.substr(url) ;
+	// In the latest (4/2021) version of webdollar UI, the version is listed
+	//   twice which offsets this parser incorrectly.
+	if (poolName == version) {
+	    url = this.substrNext(url);
+	    poolName = this.substr(url);
+	}
         poolName = decodeURIComponent(poolName);
         url = this.substrNext(url);
 

--- a/src/node/menu/CLI-Core.js
+++ b/src/node/menu/CLI-Core.js
@@ -431,7 +431,7 @@ export class CLICore {
 
                 if (getNewLink) {
 
-                    miningPoolLink = !!url ? url : await AdvancedMessages.input('Enter the new mining pool link: ');
+                    miningPoolLink = !!url ? url : await AdvancedMessages.input('Pool URLs should look like:\n  https://webdollar.io/pool/1/1/MyPoolName/<pool public key>/https:$$mybigpool.com\nEnter the new mining pool link: ');
                     Log.info('Your new MiningPool is : ' + miningPoolLink, Log.LOG_TYPE.info);
 
                 }


### PR DESCRIPTION
This fix addresses a problem where Pools-Utils.js extractPoolURL did not properly deal with a second version number in the pool URL, as seen on the public webdollar.io site such as:

https://webdollar.io/pool/1/1/CanadianStakePool/0.02/ea115a560322c557d3617732145a837af9992d729e5f8165d3b7077b22ee12a4/https:$$webdollarpool.ca:443

It would interpret "version" as 1 and "poolName" as 1, with "pool fee" as "CanadianStakePool", and "publicKey" as "0.02" etc.

Additionally the interactive CLI provides a detailed hint as to what the pool URL should look like.

Future implementations might prefer to include a regexp to sanity-check the pool URL.