### PR TITLE
Improve cpu usage when not in POW round.

### DIFF
--- a/src/common/blockchain/interface-blockchain/mining/backbone/Blockchain-Backbone-Mining.js
+++ b/src/common/blockchain/interface-blockchain/mining/backbone/Blockchain-Backbone-Mining.js
@@ -80,8 +80,10 @@ class BlockchainBackboneMining extends InterfaceBlockchainMining {
         this.bestHash = consts.BLOCKCHAIN.BLOCKS_MAX_TARGET_BUFFER;
         this.bestHashNonce = -1;
 
-        if ( BlockchainGenesis.isPoSActivated( height ) )
+        if ( BlockchainGenesis.isPoSActivated( height ) ) {
+        	this._workers.stopMining();
             return this._minePOS(block, difficulty)  ;
+        }
 
         if (consts.TERMINAL_WORKERS.CPU_MAX === -100) // NO POW MINING
             return undefined;

--- a/src/common/blockchain/interface-blockchain/mining/backbone/Workers.js
+++ b/src/common/blockchain/interface-blockchain/mining/backbone/Workers.js
@@ -152,12 +152,17 @@ class Workers {
 
         try {
 
-            console.log("Stop Mining!");
+            if (this.workers_list.length === 0)
+                return;
+
+            console.log("Stop POW Mining!");
 
             for (let i = 0; i < this.workers_list.length; i++){
                 if (this.workers_list[i] !== undefined && typeof this.workers_list[i].kill === "function")
                     this.workers_list[i].kill('SIGINT');
             }
+
+            this.workers_list = [];
 
         } catch (exception){
 


### PR DESCRIPTION
I noticed that argon2-bench2 stays open even after a POW round is finished, consuming around 50% of cpu usage according to the allocated core number, and I used to close the miner and reopen it after every POW round. Not sure if that is intended behavior, but it doesn't seem to be so. I'm not entirely familiar with node.js, but on my side POW rounds worked normally, and the changes have produced no issues and should be minimal enough to not cause further issues as far as I'm aware.