### PR TITLE
Change truthiness evaluation to continue if blockchain is actually unsynchronized

### DIFF
--- a/src/main-blockchain/Blockchain.js
+++ b/src/main-blockchain/Blockchain.js
@@ -175,7 +175,7 @@ class Blockchain{
      */
     async synchronizeBlockchain(firstTime, synchronizeComplete=false){
 
-        if ( !this.synchronized ) return;
+        if ( !!this.synchronized ) return;
 
         this.synchronized = false;
         console.warn("################### RESYNCHRONIZATION STARTED ##########");


### PR DESCRIPTION
If the blockchain is synchronized (`!!this.synchronized`), don't continue.

Otherwise, continue with the blockchain synchronization logic.